### PR TITLE
fix: reset id counter on cleanup

### DIFF
--- a/src/__tests__/fixtures/scoped-id.marko
+++ b/src/__tests__/fixtures/scoped-id.marko
@@ -1,0 +1,1 @@
+<div role="main" id:scoped="test"/>

--- a/src/__tests__/fixtures/scoped-id.marko.d.ts
+++ b/src/__tests__/fixtures/scoped-id.marko.d.ts
@@ -1,0 +1,2 @@
+declare let x: any;
+export = x;

--- a/src/__tests__/render.browser.ts
+++ b/src/__tests__/render.browser.ts
@@ -6,6 +6,7 @@ import UpdateCounter from "./fixtures/update-counter.marko";
 import HelloWorld from "./fixtures/hello-world.marko";
 import HelloName from "./fixtures/hello-name.marko";
 import Clickable from "./fixtures/clickable.marko";
+import ScopedId from "./fixtures/scoped-id.marko";
 
 afterEach(cleanup);
 
@@ -142,4 +143,12 @@ test("fireEvent waits for pending updates", async () => {
   );
 
   expect(getByText("Value: 1")).toBeInTheDocument();
+});
+
+test("it renders a stable scoped id", async () => {
+  const r1 = await render(ScopedId);
+  expect(r1.getByRole("main")).toHaveProperty("id", "c0-test");
+  cleanup();
+  const r2 = await render(ScopedId);
+  expect(r2.getByRole("main")).toHaveProperty("id", "c0-test");
 });

--- a/src/index-browser.ts
+++ b/src/index-browser.ts
@@ -118,6 +118,7 @@ export async function render<T extends Template>(
 
 export function cleanup() {
   mountedComponents.forEach(destroyComponent);
+  resetComponentIdCounter();
 }
 
 function destroyComponent(component) {
@@ -131,4 +132,11 @@ function destroyComponent(component) {
   }
 
   mountedComponents.delete(container);
+}
+
+function resetComponentIdCounter() {
+  const counter = (window as any).$MUID;
+  if (counter) {
+    counter.i = 0;
+  }
 }

--- a/src/index-browser.ts
+++ b/src/index-browser.ts
@@ -136,6 +136,7 @@ function destroyComponent(component) {
 
 function resetComponentIdCounter() {
   const counter = (window as any).$MUID;
+  /* istanbul ignore else */
   if (counter) {
     counter.i = 0;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Reset's the global id counter when `cleanup` is called

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

When `:scoped` values are used, they should be stable.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
