### PR TITLE
feat: expose helper to perform action and wait for update

### DIFF
--- a/src/__tests__/render.browser.ts
+++ b/src/__tests__/render.browser.ts
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen, cleanup } from "..";
+import { render, fireEvent, screen, cleanup, act } from "..";
 import Counter from "./fixtures/counter.marko";
 import LegacyCounter from "./fixtures/legacy-counter";
 import UpdateCounter from "./fixtures/update-counter.marko";
@@ -120,6 +120,14 @@ test("can render into a different container", async () => {
   const container = document.createElement("main");
   const { getByText } = await render(HelloWorld, null, { container });
   expect(getByText("Hello World")).toHaveProperty("parentNode", container);
+});
+
+test("act waits for pending updates", async () => {
+  const { getByText } = await render(Counter);
+  expect(getByText(/Value: 0/)).toBeInTheDocument();
+
+  await act(() => getByText("Increment").click());
+  expect(getByText("Value: 1")).toBeInTheDocument();
 });
 
 test("fireEvent waits for pending updates", async () => {

--- a/src/__tests__/render.server.ts
+++ b/src/__tests__/render.server.ts
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, cleanup } from "..";
+import { render, screen, fireEvent, cleanup, act } from "..";
 import Counter from "./fixtures/counter.marko";
 import LegacyCounter from "./fixtures/legacy-counter";
 import Clickable from "./fixtures/clickable.marko";
@@ -57,11 +57,20 @@ test("fails when checking emitted events", async () => {
   );
 });
 
+test("fails when calling act", async () => {
+  const { getByText } = await render(Counter);
+  await expect(
+    act(() => getByText("Increment").click())
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"Cannot perform client side interaction tests on the server side. Please use @marko/testing-library in a browser environment."`
+  );
+});
+
 test("fails when emitting events", async () => {
   const { getByText } = await render(Counter);
   await expect(
     fireEvent.click(getByText("Increment"))
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"Cannot fire events when testing on the server side. Please use @marko/testing-library in a browser environment."`
+    `"Cannot perform client side interaction tests on the server side. Please use @marko/testing-library in a browser environment."`
   );
 });

--- a/src/index-browser.ts
+++ b/src/index-browser.ts
@@ -16,7 +16,7 @@ interface MountedComponent {
 }
 const mountedComponents = new Set<MountedComponent>();
 
-export { FireFunction, FireObject, fireEvent } from "./shared";
+export { FireFunction, FireObject, fireEvent, act } from "./shared";
 
 export type RenderResult = AsyncReturnValue<typeof render>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from "@testing-library/dom";
 import { autoCleanupEnabled } from "./shared";
 
-export { FireFunction, FireObject, fireEvent } from "./shared";
+export { FireFunction, FireObject, fireEvent, act } from "./shared";
 
 export type RenderResult = AsyncReturnValue<typeof render>;
 


### PR DESCRIPTION
## Description

This PR exposes a helper called `act` which allows for an easy way to perform any mutation and wait for Marko components to update. It works similarly to `await fireEvent` helpers and the core implementation has been refactored for all of those helpers to use this underlying helper.

## Motivation and Context

This makes it easy to do something like:

```js
import { render, act } from "@marko/testing-library";

const { getByText } = await render(template);

await act(() => getByText("My Button").click());
```

or

```js
import userEvent from "@testing-library/user-event";
import { render, act } from "@marko/testing-library";

const { getByDisplayValue } = await render(template);

await act(() => userEvent.type(getByDisplayValue("Hello"), " World"));
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
